### PR TITLE
chore(ansible.cfg): silence force_valid_group_names warning (#169)

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 deprecation_warnings = False
 command_warnings = False
-force_valid_group_names = ignore
+# silently = allow dots/hyphens in host names (r42.admin-wazuh etc.) without warning every run
+force_valid_group_names = silently
 host_key_checking = False

--- a/ansible_no_skipped.cfg
+++ b/ansible_no_skipped.cfg
@@ -6,3 +6,6 @@ stdout_callback = no_skipped
 
 # optionnal :
 display_skipped_hosts = False
+
+# silently = allow dots/hyphens in host names (r42.admin-wazuh etc.) without warning every run
+force_valid_group_names = silently

--- a/ansible_no_skipped_json.cfg
+++ b/ansible_no_skipped_json.cfg
@@ -7,6 +7,9 @@ stdout_callback = json
 # stdout_callback = minimal
 display_skipped_hosts = False
 
+# silently = allow dots/hyphens in host names (r42.admin-wazuh etc.) without warning every run
+force_valid_group_names = silently
+
 [callback_json_no_skipped]
 
 json_indent = 2


### PR DESCRIPTION
Side effect of WAVE_01 integration testing.

Sets `force_valid_group_names = silently` in 3 ansible.cfg files used by the devkit wrapper scripts (proxmox_vm.list / vm_id.* actions). Same accept behavior, no more `[WARNING]: Invalid characters were found in group names` printed at every invocation.

Files :
- `ansible.cfg` (ignore → silently)
- `ansible_no_skipped.cfg` (none → silently)
- `ansible_no_skipped_json.cfg` (none → silently)

Companion PR in range42/range42 covers the corresponding 2 ansible.cfg files in that repo.

