### PR TITLE
fix(devkit): use RANGE42_INFRASTRUCTURE_CODENAME as Ansible host pattern + fix non-TTY empty stdin

### DIFF
--- a/devkit_proxmox.STDIN.stdin_or_jsons.to.jsons.sh
+++ b/devkit_proxmox.STDIN.stdin_or_jsons.to.jsons.sh
@@ -52,7 +52,10 @@ NEW_KEY_FIELD_NAME_FROM_STDIN=$(extract_new_key_field_name_from_stdin "$1")
 
 JSON_LINE_REQ=$(
 
-    { [ -t 0 ] && printf "%s\n" "$VAULT_NODE" || cat -; } |
+    { [ -t 0 ] && printf "%s
+" "$VAULT_NODE" || { _STDIN=$(cat -); [ -n "$_STDIN" ] && printf "%s
+" "$_STDIN" || printf "%s
+" "$VAULT_NODE"; }; } |
         jq -R -c --arg key "$NEW_KEY_FIELD_NAME_FROM_STDIN" '
             (fromjson? // .) as $v_to_evaluate |
                 if ($v_to_evaluate | type) == "object" then

--- a/proxmox__inc.jsons.basic_vm_actions.to.jsons.sh
+++ b/proxmox__inc.jsons.basic_vm_actions.to.jsons.sh
@@ -265,7 +265,9 @@ if [ ! -t 0 ]; then
       assign_if_not_empty "dest_proxmox_storage" "$line" ".dest_proxmox_storage"
 
       # ARG_ACTION=$(printf "%s\n" "$line" | jq -r ".action")
-      PROXMOX_NODE=$(printf "%s\n" "$line" | jq -r ".proxmox_node")
+      PROXMOX_NODE=$(printf "%s
+" "$line" | jq -r ".proxmox_node")
+      ANSIBLE_HOST="${RANGE42_INFRASTRUCTURE_CODENAME:-$PROXMOX_NODE}"
 
       #### DEBUG purpose.
 
@@ -282,7 +284,7 @@ if [ ! -t 0 ]; then
             (
                 ANSIBLE_CONFIG="$ANSIBLE_CONFIG" \
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         ansible-playbook -i "$INVENTORY" "${VAULT_ARGS[@]}" /dev/stdin <<PLAYBOOK
-            - hosts: $PROXMOX_NODE
+            - hosts: $ANSIBLE_HOST
               gather_facts: false
               vars_files:
                 - "$PLAYBOOK_VARS_FILE"
@@ -306,7 +308,7 @@ EOF
       (
         ANSIBLE_CONFIG="$ANSIBLE_CONFIG" \
           ansible-playbook -i "$INVENTORY" "${VAULT_ARGS[@]}" /dev/stdin <<EOF
-      - hosts: $PROXMOX_NODE
+      - hosts: $ANSIBLE_HOST
         gather_facts: false
         vars_files:
           - "$PLAYBOOK_VARS_FILE"


### PR DESCRIPTION
Closes #111

## Summary

- `proxmox__inc.jsons.basic_vm_actions.to.jsons.sh`: separate `ANSIBLE_HOST` (for `- hosts:`) from `PROXMOX_NODE` (for the proxmox API variable). `ANSIBLE_HOST` uses `RANGE42_INFRASTRUCTURE_CODENAME` when set (the Ansible inventory host key, e.g. `hv-lab-01`) and falls back to `PROXMOX_NODE` (the PVE cluster node name, e.g. `pve`).
- `devkit_proxmox.STDIN.stdin_or_jsons.to.jsons.sh`: when `cat -` returns empty (non-TTY context such as `$(...)` subshell with no piped input), fall back to `$VAULT_NODE` instead of silently producing nothing.

## Test plan

- [ ] `range42-context use <codename> <scenario>` on a codename-based deployment
- [ ] `range42-context delete-everything` completes without "no VM data" error
- [ ] `proxmox_vm.list.to.jsons.sh` returns VM data when run inside `$()` 
- [ ] Piping an explicit node to the script still works (stdin path not broken)