### PR TITLE
WAVE_03 close

### DIFF
--- a/_waves-testing.md
+++ b/_waves-testing.md
@@ -15,7 +15,14 @@ the wave (e.g. WAVE_01 has 3 umbrellas across 3 repos). A single umbrella
 covering cross-repo work is also valid (e.g. WAVE_02 has 1 umbrella on
 playbooks that also tracks devkit work via SHA refs in its body).
 
-## WAVE_02 - in progress
+## WAVE_03 - in progress
+
+- range42/range42-playbooks#62
+- range42/range42#174
+- range42/range42-ansible_roles-debug-devkit#110
+- range42/range42-catalog#164
+
+## WAVE_02 - 2026-05-22
 
 - range42/range42-playbooks#55
 


### PR DESCRIPTION

WAVE_03 closure (2026-05-22 to 2026-06-04, 5 cycles). Full per-cycle PR-by-PR detail lives in the umbrella issues linked at each section header.

## PRs / issues in this release

### range42/range42 - umbrella range42/range42#174

- #175 (doc, Cycle A)
- #176 (locale fix, Cycle A)
- #87, #116, #136 (3 contributor PRs partial-landed, Cycle B)
- #127, #128, #129 (3 contributor PRs declined, Cycle B)
- #186 (catalog-try switch, Cycle C)
- #187 (catalog-try wizard mode, Cycle D)
- #188 (catalog-try-list admin/non-admin split, Cycle D)
- #190 (snapshot-list, Cycle D)
- #191 (SSH key auto-unlock from vault, Cycle E)
- #192 (range42-context show-* commands, Cycle E)
- #193 (--catalog-try prefill() fix, Cycle E)
- #196 (docs alignment, Cycle E)

### range42/range42-playbooks - umbrella range42/range42-playbooks#62

- #63 (inventory group rename, Cycle A)
- #64 (catalog_try scenario + element_deploy playbook, Cycle C)
- #65 (catalog_try playbook hardening, Cycle D)

### range42/range42-catalog - umbrella range42/range42-catalog#164

- #166 (L2 contract POC on blank_template, Cycle C)
- #148, #149, #150, #151, #152 (5 contributor PRs, Cycle D)
- #167, #168, #169, #170 (4 maintainer fix issues, Cycle D)

### range42/range42-ansible_roles-debug-devkit - umbrella range42/range42-ansible_roles-debug-devkit#110

- passive (no code change, wave alignment only)

## Closes (per repo)

- range42/range42 PR : `Closes #174`
- range42/range42-playbooks PR : `Closes #62`
- range42/range42-catalog PR : `Closes #164`
- range42/range42-ansible_roles-debug-devkit PR : `Closes #110`

