### PR TITLE
fix(devkit): remove SC2034 dead variable assignments

### DIFF
--- a/devkit_proxmox.STDIN.normalize.to.jsons.sh
+++ b/devkit_proxmox.STDIN.normalize.to.jsons.sh
@@ -5,7 +5,6 @@
 parse_stdin_schema() {
     local SCHEMA=("$@")
     local STDIN_DATA KEY_NAME KEY_TYPE
-    local SIMPLE_VALUE SIMPLE_TYPE
     local KV_PAIR=()
 
     if [ -t 0 ]; then
@@ -14,15 +13,6 @@ parse_stdin_schema() {
     fi
 
     STDIN_DATA=$(cat -)
-
-    if [[ "$STDIN_DATA" =~ ^[0-9]+$ ]]; then
-        SIMPLE_TYPE="INT"
-        SIMPLE_VALUE="$STDIN_DATA"
-
-    elif [[ "$STDIN_DATA" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-        SIMPLE_TYPE="STR"
-        SIMPLE_VALUE="$STDIN_DATA"
-    fi
 
     #
     # PURE TEXT CASE

--- a/proxmox_vm.vm_id.get_usage.to.jsons.sh
+++ b/proxmox_vm.vm_id.get_usage.to.jsons.sh
@@ -9,8 +9,6 @@
 set -euo pipefail
 
 ACTION="vm_list_usage"
-# DEFAULT_OUTPUT_JSON=true # todo
-DEFAULT_OUTPUT_JSON=true
 # ARG_VM_NAME_FILTER=""
 
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
@@ -75,16 +73,12 @@ proxmox__inc.warmup_checks_stdin.sh
 #
 #### #### #### #### #### #### #### #### #### #### #### #### #### #### #### ####
 
-OUTPUT_JSON="$DEFAULT_OUTPUT_JSON"
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --json)
-    OUTPUT_JSON=true
     shift
     ;;
   --text)
-    OUTPUT_JSON=false
     shift
     ;;
   -*)


### PR DESCRIPTION
Closes #117

## Summary

Remove ShellCheck SC2034 dead variable assignments from two scripts.

- `devkit_proxmox.STDIN.normalize.to.jsons.sh`: drop `SIMPLE_VALUE`/`SIMPLE_TYPE` local declarations and the `if/elif` block that assigned them — neither variable is ever read; the call sites re-check `STDIN_DATA` directly.
- `proxmox_vm.vm_id.get_usage.to.jsons.sh`: drop `DEFAULT_OUTPUT_JSON` TODO placeholder, `OUTPUT_JSON` derivation, and the `--json`/`--text` write-only assignments — `OUTPUT_JSON` was never consumed downstream.

No behaviour change. Source files only — no CI config touched.

## Commits

- `22494e0 fix(devkit): remove SC2034 dead variable assignments`